### PR TITLE
Fix high score saving logic

### DIFF
--- a/src/main/java/com/example/ap2superhexagon/GameController.java
+++ b/src/main/java/com/example/ap2superhexagon/GameController.java
@@ -179,9 +179,6 @@ public class GameController {
             long elapsedMillis = System.currentTimeMillis() - gameStartTime;
             HighScoreManager.saveIfNewHighScore(currentPlayerName, elapsedMillis);
             stopGame();
-
-//            elapsedMillis = (long)(timeSinceGameStart * 1000);
-            HighScoreManager.saveIfNewHighScore(currentPlayerName, elapsedMillis);
             if (GameHistoryManager.isHistoryEnabled()) {
                 GameHistoryManager.saveGameRecord(currentPlayerName, elapsedMillis);
             }


### PR DESCRIPTION
## Summary
- stop saving best score twice when game ends

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d4deed8dc832bb0004f535867ec40